### PR TITLE
Pass std::string_view by value

### DIFF
--- a/zedio/common/util/thread.hpp
+++ b/zedio/common/util/thread.hpp
@@ -16,8 +16,8 @@ auto get_tid() noexcept -> pid_t {
 
 static thread_local std::string t_name;
 
-auto set_thread_name(const std::string_view &str) {
-    t_name = str;
+auto set_thread_name(std::string_view name) {
+    t_name = name;
 }
 
 auto get_thread_name() -> std::string_view {

--- a/zedio/fs/io.hpp
+++ b/zedio/fs/io.hpp
@@ -76,7 +76,7 @@ public:
 public:
     template <class FileType>
     [[REMEMBER_CO_AWAIT]]
-    static auto open(const std::string_view &path, int flags, mode_t mode) {
+    static auto open(std::string_view path, int flags, mode_t mode) {
         class Open : public io::detail::IORegistrator<Open> {
         private:
             using Super = io::detail::IORegistrator<Open>;

--- a/zedio/log/file.hpp
+++ b/zedio/log/file.hpp
@@ -11,7 +11,7 @@ namespace zedio::log::detail {
 
 class LogFile : util::Noncopyable {
 public:
-    LogFile(const std::string_view &file_base_name)
+    LogFile(std::string_view file_base_name)
         : file_base_name_{file_base_name} {
         this->roll();
         ofs_.rdbuf()->pubsetbuf(buffer_, sizeof(buffer_));

--- a/zedio/log/logger.hpp
+++ b/zedio/log/logger.hpp
@@ -24,7 +24,7 @@ public:
         : fmt_(std::forward<T>(fmt))
         , sl_(std::move(sl)) {}
 
-    constexpr auto fmt() const -> const std::string_view & {
+    constexpr auto fmt() const -> std::string_view {
         return fmt_;
     }
 
@@ -127,7 +127,7 @@ public:
 
 class FileLogger : public BaseLogger<FileLogger> {
 public:
-    FileLogger(const std::string_view &file_base_name)
+    FileLogger(std::string_view file_base_name)
         : file_{file_base_name}
         , current_buffer_{new Buffer}
         , thread_{&FileLogger::work, this} {

--- a/zedio/log/manager.hpp
+++ b/zedio/log/manager.hpp
@@ -10,7 +10,7 @@ namespace zedio::log {
 namespace detail {
     class LogManager : util::Noncopyable {
     public:
-        auto make_logger(const std::string &logger_name, const std::string_view &file_base_name)
+        auto make_logger(const std::string &logger_name, std::string_view file_base_name)
             -> FileLogger & {
             loggers_.emplace(logger_name, file_base_name);
             return loggers_.at(logger_name);

--- a/zedio/net/addr.hpp
+++ b/zedio/net/addr.hpp
@@ -39,7 +39,7 @@ public:
 
 public:
     [[nodiscard]]
-    static auto parse(const std::string_view &ip) -> Result<Ipv4Addr> {
+    static auto parse(std::string_view ip) -> Result<Ipv4Addr> {
         uint32_t addr;
         if (::inet_pton(AF_INET, ip.data(), &addr) != 1) {
             return std::unexpected{make_sys_error(errno)};
@@ -98,7 +98,7 @@ public:
 
 public:
     [[nodiscard]]
-    static auto parse(const std::string_view &ip) -> Result<Ipv6Addr> {
+    static auto parse(std::string_view ip) -> Result<Ipv6Addr> {
         in6_addr addr;
         if (::inet_pton(AF_INET6, ip.data(), &addr) != 1) [[unlikely]] {
             return std::unexpected{make_sys_error(errno)};
@@ -207,7 +207,7 @@ public:
     }
 
 public:
-    static auto parse(const std::string_view &host_name, uint16_t port) -> Result<SocketAddr> {
+    static auto parse(std::string_view host_name, uint16_t port) -> Result<SocketAddr> {
         addrinfo hints{};
         hints.ai_flags = AI_NUMERICSERV;
         addrinfo *result{nullptr};
@@ -235,7 +235,7 @@ class UnixSocketAddr {
 
     UnixSocketAddr() = default;
 
-    UnixSocketAddr(const std::string_view &path) {
+    UnixSocketAddr(std::string_view path) {
         addr_.sun_family = AF_UNIX;
         std::memcpy(addr_.sun_path, path.data(), path.size());
     }


### PR DESCRIPTION
It seems to be more advisable to pass std::string_view types by value.

https://quuxplusone.github.io/blog/2021/11/09/pass-string-view-by-value/
https://quuxplusone.github.io/blog/2021/11/19/string-view-by-value-ps/