### PR TITLE
Fix latch try_wait semantics

### DIFF
--- a/tests/latch_test.cpp
+++ b/tests/latch_test.cpp
@@ -10,21 +10,23 @@ using namespace zedio;
 
 auto latch_test(Latch &latch_, [[maybe_unused]] std::size_t index, std::atomic<std::size_t> &sum)
     -> Task<void> {
+    sum.fetch_add(1, std::memory_order::relaxed);
     // LOG_INFO("latch_test {} suspend", index);
     co_await latch_.arrive_and_wait();
     // LOG_INFO("latch_test {} resume", index);
-    sum.fetch_add(1, std::memory_order::relaxed);
 }
 
 auto test(std::size_t n) -> Task<void> {
     Latch                    latch{static_cast<std::ptrdiff_t>(n)};
     std::atomic<std::size_t> sum = 0;
+    assert(n >= 1);
+    assert(latch.try_wait() == false);
     for (auto i = 0uz; i < n - 1; i += 1) {
         spawn(latch_test(latch, i, sum));
     }
-    co_await latch.arrive_and_wait();
     sum.fetch_add(1, std::memory_order::relaxed);
-    co_await time::sleep(5s);
+    co_await latch.arrive_and_wait();
+    // co_await time::sleep(5s);
     console.info("expected: {}, actual {}", n, sum.load());
     co_return;
 }


### PR DESCRIPTION
标准库中latch try_wait() 是检查计数器是否为零, 为零的时候返回true, zedio中现在的实现是反过来的.

[1] https://en.cppreference.com/w/cpp/thread/latch/try_wait